### PR TITLE
Fix multiple definitions for `Py_fclose`

### DIFF
--- a/pythoncapi_compat.h
+++ b/pythoncapi_compat.h
@@ -1968,7 +1968,7 @@ static inline FILE* Py_fopen(PyObject *path, const char *mode)
 #endif
 }
 
-int Py_fclose(FILE *file)
+static inline int Py_fclose(FILE *file)
 {
     return fclose(file);
 }


### PR DESCRIPTION
While testing the lastest changes in `pythoncapi_compat.h` with mypy, I encountered this error
```
pythoncapi_compat.h:1972: multiple definition of `Py_fclose'
```

Believe `Py_fclose` is missing `static inline`.